### PR TITLE
Canvas de casteljau

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ot.interactions_viewer",
-  "version": "0.0.7",
+  "version": "0.0.10",
   "description": "Protein interaction viewer for Open Targets",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-browserify": "^0.5.1",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^3.0.0",
+    "gulp-sourcemaps": "^2.6.0",
     "gulp-uglify": "^2.0.0",
     "gulp-util": "^3.0.7",
     "karma": "^1.4.1",
@@ -39,7 +40,9 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
     "sass": "^0.5.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.9.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
# Key differences:
* Use de Casteljau method to draw a bezier from t0 to tn when animating curves instead of linear interpolation from tn to tn1. Consequences of this:
  * Canvas context now cleared on every paint (which seemed to look better) in *stepDrawLine*
  * Bezier links which remain between interactions (ie. are not in a state of animation when a user clicks a node), the *stayLinks*, are drawn in full on each paint, by *drawLine* method
